### PR TITLE
Checked and added testing for Undefined-type stat generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - colin seifer* modified type assignment to assign into class first, then phylum, then kingdom
 - colin seifer* removed some test requirements since coding stats was moved to *danielle dishop*
 - colin seifer* removed some test requirements since battle calculations are out of the scope of this iteration
+- Danielle Dishop* added Undefined type in stat generation testing block (Undefined typed objects were already generating stats correctly by default)
 
 ## Placeholder UI
 

--- a/test/statTest.py
+++ b/test/statTest.py
@@ -281,5 +281,17 @@ class TestStats(unittest.TestCase):
                     flag = False
         self.assertTrue(flag)
 
+    def test_Undefined_no_Quality(self):
+        # Undefined observations have no increased or decreased stats
+        # Uses a flag to ensure all stats are assigned correctly
+        flag = True
+        undef = Stats('Undefined', 0)
+        undefStats = undef.AssignStats()
+        for stat in undefStats:
+            statValue = undefStats.get(stat)
+            if (statValue < FLOOR) or (statValue > CEILING):
+                flag = False
+        self.assertTrue(flag)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Stats were already generating correctly by default for undefined objects, so just added the test to check that they were generating within the correct bounds.

Linked to Jira ticket C4G5NP-83